### PR TITLE
feat: enrich ego future state features

### DIFF
--- a/data_process_n_move_to_nubes_pnc.sh
+++ b/data_process_n_move_to_nubes_pnc.sh
@@ -10,7 +10,10 @@ echo "Step 1: Running data processing..."
 # You can modify these paths if needed.
 NUPLAN_DATA_PATH="/media/user/E/dataset/nuplan-v1.1/splits/trainval"
 NUPLAN_MAP_PATH="/media/user/E/dataset/maps"
-TRAIN_SET_PATH="/media/user/E/dataset/processed/"
+# 공통 경로 변수 (한 곳만 바꾸면 전체에 반영됨)
+TRAIN_SET_NAME="processed_ego_past_future"
+TRAIN_SET_PATH="/media/user/E/dataset/${TRAIN_SET_NAME}"
+TRAIN_JSON_PATH="${TRAIN_SET_NAME}_json"
 
 # Run the data processing script
 # This is the command from data_process_pnc.sh
@@ -40,9 +43,11 @@ echo "Cleaning finished."
 echo "---------------------------------"
 echo "Step 3: Uploading processed data..."
 
-nubescli dir-upload labs-mlops/ad/research/pnc/hsb/dataset/processed \
+nubescli dir-upload "labs-mlops/ad/research/pnc/hsb/dataset/${TRAIN_SET_NAME}" \
                     "$TRAIN_SET_PATH" \
                     -e -j 128
 
+nubescli upload labs-mlops/ad/research/pnc/hsb/dataset/${TRAIN_JSON_PATH}/diffusion_planner_training.json \
+                    /media/user/E/projects/Diffusion-Planner/diffusion_planner_training.json
 echo "Upload complete."
 echo "Pipeline finished successfully."

--- a/data_process_test.sh
+++ b/data_process_test.sh
@@ -1,7 +1,7 @@
 ###################################
 # User Configuration Section
 ###################################
-NUPLAN_DATA_PATH="/home/hsb/nuplan/dataset/nuplan-v1.1/splits/trainval" # nuplan training data path (e.g., "/data/nuplan-v1.1/trainval")
+NUPLAN_DATA_PATH="/home/hsb/nuplan/dataset/nuplan-v1.1/splits/trainval_test" # nuplan training data path (e.g., "/data/nuplan-v1.1/trainval")
 NUPLAN_MAP_PATH="/home/hsb/nuplan/dataset/maps" # nuplan map path (e.g., "/data/nuplan-v1.1/maps")
 
 TRAIN_SET_PATH="/home/hsb/nuplan/dataset/processed/" # preprocess training data

--- a/diffusion_planner/data_process/data_processor.py
+++ b/diffusion_planner/data_process/data_processor.py
@@ -192,6 +192,8 @@ class DataProcessor(object):
                                      self._max_elements, self._max_points)
             '''
             ego & agents future
+            ego_agent_future : rear axle x,y, ~~~
+            ego_agent_future_11_dim : center x,y, ~~~
             '''
             ego_agent_future, ego_agent_future_11_dim = get_ego_future_array_from_scenario(
                 scenario, ego_state, self.num_future_poses,
@@ -240,8 +242,8 @@ class DataProcessor(object):
                 "token": token,
                 "ego_agent_past": ego_agent_past,
                 "ego_current_state": ego_current_state,
-                "ego_agent_future": ego_agent_future,
-                "ego_agent_future_11_dim": ego_agent_future_11_dim,
+                "ego_agent_future": ego_agent_future, # rear_axle x,y
+                "ego_agent_future_11_dim": ego_agent_future_11_dim, # center x,y
                 "neighbor_agents_past": neighbor_agents_past,
                 "neighbor_agents_future": neighbor_agents_future,
                 "static_objects": static_objects
@@ -370,7 +372,8 @@ class DataProcessor(object):
                 'green',
                 alpha=0.8 if t == ego_agent_future_11_dim.shape[0] - 1 else 0.5,
                 show_heading=True,
-                time_info=time_info)
+                # time_info=time_info
+            )
 
         # 4. Neighbor vehicles 그리기
         for p in range(neighbor_agents_past.shape[0]):  # P=32

--- a/diffusion_planner/data_process/data_processor.py
+++ b/diffusion_planner/data_process/data_processor.py
@@ -251,7 +251,9 @@ class DataProcessor(object):
             # 디버깅용 그림 그리기
             if  self._wandb_enabled or self.config.save_image:
                 print("Visualizing scenario:", map_name, token)
-                self._visualize_scenario(ego_agent_past, neighbor_agents_past,
+                self._visualize_scenario(ego_agent_past,
+                                         ego_agent_future_11_dim,
+                                         neighbor_agents_past,
                                          vector_map['lanes'], map_name, token)
 
             self.save_to_disk(self._save_dir, data)
@@ -259,6 +261,7 @@ class DataProcessor(object):
     def _visualize_scenario(
         self,
         ego_agent_past: np.ndarray,  # (T=21, 11)
+        ego_agent_future_11_dim: np.ndarray,  # (Tf, 11)
         neighbor_agents_past: np.ndarray,  # (P=32, T=21, 11)
         lanes: np.ndarray,  # (N=70, V=25, 12)
         map_name: str,
@@ -269,6 +272,8 @@ class DataProcessor(object):
         Args:
             ego_agent_past: (T=21, 11) ego vehicle 과거 상태
                 - x, y, cos(yaw), sin(yaw), v_x, v_y, width, length
+            ego_agent_future_11_dim: (Tf, 11) ego vehicle 미래 상태
+                - x, y, cos(yaw), sin(yaw), v_x, v_y, width, length + 3 one hot
             neighbor_agents_past: (P=32, T=21, 11) neighbor agents 과거 상태
                 - x, y, cos(yaw), sin(yaw), v_x, v_y, width, length + 3 one hot
             lanes: (N=70, V=25, 12) lane polylines
@@ -314,7 +319,7 @@ class DataProcessor(object):
                         linewidth=1,
                         alpha=0.7)
 
-        # 2. Ego vehicle 그리기
+        # 2. Ego vehicle 과거 그리기
         for t in range(ego_agent_past.shape[0]):  # T=21
             # 전체 8차원 벡터가 모두 0인 경우만 유효하지 않은 데이터로 처리
             if np.all(ego_agent_past[t] == 0):
@@ -341,7 +346,33 @@ class DataProcessor(object):
                 time_info=time_info  # 시간 정보 추가
             )
 
-        # 3. Neighbor vehicles 그리기
+        # 3. Ego vehicle 미래 그리기
+        for t in range(ego_agent_future_11_dim.shape[0]):  # Tf
+            if np.all(ego_agent_future_11_dim[t] == 0):
+                continue
+            x, y = ego_agent_future_11_dim[t, 0], ego_agent_future_11_dim[t, 1]
+            cos_yaw, sin_yaw = (ego_agent_future_11_dim[t, 2],
+                                 ego_agent_future_11_dim[t, 3])
+            width, length = (ego_agent_future_11_dim[t, 6],
+                             ego_agent_future_11_dim[t, 7])
+
+            yaw = math.atan2(sin_yaw, cos_yaw)
+            time_info = (t + 1) * (self.future_time_horizon /
+                                   self.num_future_poses)
+
+            rect = self._draw_vehicle_rectangle(
+                ax,
+                x,
+                y,
+                yaw,
+                width,
+                length,
+                'green',
+                alpha=0.8 if t == ego_agent_future_11_dim.shape[0] - 1 else 0.5,
+                show_heading=True,
+                time_info=time_info)
+
+        # 4. Neighbor vehicles 그리기
         for p in range(neighbor_agents_past.shape[0]):  # P=32
             agent_trajectory = neighbor_agents_past[p, :, :]  # (T=21, 11)
 
@@ -389,12 +420,12 @@ class DataProcessor(object):
                                                     current_color,
                                                     alpha=0.8)
 
-        # 4. 그래프 설정
+        # 5. 그래프 설정
         ax.set_xlabel('X (m)', color='white')
         ax.set_ylabel('Y (m)', color='white')
         ax.tick_params(colors='white')
         ax.grid(True, alpha=0.3, color='gray')
-        # 5. 범례 추가
+        # 6. 범례 추가
         legend_elements = [
             plt.Line2D([0], [0],
                        marker='s',
@@ -402,6 +433,13 @@ class DataProcessor(object):
                        markerfacecolor='red',
                        markersize=10,
                        label='Ego Vehicle',
+                       linestyle='None'),
+            plt.Line2D([0], [0],
+                       marker='s',
+                       color='w',
+                       markerfacecolor='green',
+                       markersize=10,
+                       label='Ego Future',
                        linestyle='None'),
             plt.Line2D([0], [0],
                        marker='s',
@@ -441,15 +479,14 @@ class DataProcessor(object):
                   labelcolor='white',
                   facecolor='black',
                   edgecolor='white')
-
-        # 6. 제목 설정
+        # 7. 제목 설정
         ax.set_title(f'Scenario Visualization - {map_name}_{token}',
                      color='white',
                      fontsize=14,
                      pad=20)
         fig.tight_layout(pad=0.5)
 
-        # 7. wandb에 이미지 업로드
+        # 8. wandb에 이미지 업로드
         if self._wandb_enabled:
             # (1) Figure → wandb.Image 직접 전달
             wandb_image = wandb.Image(fig, caption=f"{map_name}_{token}")

--- a/diffusion_planner/data_process/data_processor.py
+++ b/diffusion_planner/data_process/data_processor.py
@@ -193,9 +193,15 @@ class DataProcessor(object):
             '''
             ego & agents future
             '''
-            ego_agent_future = get_ego_future_array_from_scenario(
+            ego_agent_future, ego_agent_future_11_dim = get_ego_future_array_from_scenario(
                 scenario, ego_state, self.num_future_poses,
                 self.future_time_horizon)
+
+            Tf, Df = ego_agent_future_11_dim.shape
+            assert Tf == self.num_future_poses, (
+                "Ego agent future states should have T time steps")
+            assert Df == 11, (
+                "Ego agent future states should have 11 dimensions (x, y, cos(yaw), sin(yaw), v_x, v_y, width, length, agent type)")
 
             present_tracked_objects = scenario.initial_tracked_objects.tracked_objects
             future_tracked_objects = [
@@ -235,6 +241,7 @@ class DataProcessor(object):
                 "ego_agent_past": ego_agent_past,
                 "ego_current_state": ego_current_state,
                 "ego_agent_future": ego_agent_future,
+                "ego_agent_future_11_dim": ego_agent_future_11_dim,
                 "neighbor_agents_past": neighbor_agents_past,
                 "neighbor_agents_future": neighbor_agents_future,
                 "static_objects": static_objects

--- a/diffusion_planner/data_process/ego_process.py
+++ b/diffusion_planner/data_process/ego_process.py
@@ -9,6 +9,8 @@ from nuplan.planning.training.preprocessing.features.trajectory_utils import con
 from nuplan.common.actor_state.vehicle_parameters import get_pacifica_parameters
 from nuplan.planning.scenario_builder.nuplan_db.nuplan_scenario import NuPlanScenario
 
+from diffusion_planner.data_process.utils import convert_absolute_quantities_to_relative
+
 def get_ego_past_array_from_scenario(scenario: NuPlanScenario, num_past_poses,
                                      past_time_horizon):
 
@@ -43,15 +45,15 @@ def sampled_past_ego_states_to_array(
 
     output = np.zeros((len(past_ego_states), 7), dtype=np.float64)
     for i in range(0, len(past_ego_states), 1):
-        output[i, EgoInternalIndex.x()] = past_ego_states[i].rear_axle.x
-        output[i, EgoInternalIndex.y()] = past_ego_states[i].rear_axle.y
+        output[i, EgoInternalIndex.x()] = past_ego_states[i].center.x
+        output[i, EgoInternalIndex.y()] = past_ego_states[i].center.y
         output[
             i,
-            EgoInternalIndex.heading()] = past_ego_states[i].rear_axle.heading
+            EgoInternalIndex.heading()] = past_ego_states[i].center.heading
         output[i, EgoInternalIndex.vx(
-        )] = past_ego_states[i].dynamic_car_state.rear_axle_velocity_2d.x
+        )] = past_ego_states[i].dynamic_car_state.center_velocity_2d.x
         output[i, EgoInternalIndex.vy(
-        )] = past_ego_states[i].dynamic_car_state.rear_axle_velocity_2d.y
+        )] = past_ego_states[i].dynamic_car_state.center_velocity_2d.y
         # output[i, EgoInternalIndex.ax(
         # )] = past_ego_states[i].dynamic_car_state.rear_axle_acceleration_2d.x
         # output[i, EgoInternalIndex.ay(
@@ -65,20 +67,79 @@ def sampled_past_ego_states_to_array(
     return output
 
 
-def get_ego_future_array_from_scenario(scenario, current_ego_state,
-                                       num_future_poses, future_time_horizon):
+def sampled_future_ego_states_to_array(
+        future_ego_states: List[EgoState]) -> npt.NDArray[np.float32]:
+    """Convert future ego states to a numpy array.
+
+    Args:
+        future_ego_states: List of future ego states.
+
+    Returns:
+        Array of shape (T, 7) with elements
+        [x, y, heading, vx, vy, width, length].
+    """
+
+    output = np.zeros((len(future_ego_states), 7), dtype=np.float64)
+    for i in range(len(future_ego_states)):
+        output[i, EgoInternalIndex.x()] = future_ego_states[i].center.x
+        output[i, EgoInternalIndex.y()] = future_ego_states[i].center.y
+        output[i, EgoInternalIndex.heading()] = future_ego_states[i].center.heading
+        output[i, EgoInternalIndex.vx(
+        )] = future_ego_states[i].dynamic_car_state.center_velocity_2d.x
+        output[i, EgoInternalIndex.vy(
+        )] = future_ego_states[i].dynamic_car_state.center_velocity_2d.y
+        output[i, EgoInternalIndex.ax(
+        )] = future_ego_states[i].car_footprint.width
+        output[i, EgoInternalIndex.ay(
+        )] = future_ego_states[i].car_footprint.length
+
+    return output
+
+
+def get_ego_future_array_from_scenario(scenario: NuPlanScenario,
+                                       current_ego_state: EgoState,
+                                       num_future_poses: int,
+                                       future_time_horizon: float) -> npt.NDArray[np.float32]:
+    """Return ego future states in ego-centric coordinates with rich features.
+
+    The returned array has shape (T, 11) where each element consists of
+    [x, y, cos(yaw), sin(yaw), vx, vy, width, length, one_hot(3)].
+    """
 
     future_trajectory_absolute_states = scenario.get_ego_future_trajectory(
         iteration=0,
         num_samples=num_future_poses,
         time_horizon=future_time_horizon)
 
+    future_states_array = sampled_future_ego_states_to_array(
+        list(future_trajectory_absolute_states))
+
+    anchor_ego_state = np.array([
+        current_ego_state.rear_axle.x,
+        current_ego_state.rear_axle.y,
+        current_ego_state.rear_axle.heading,
+    ],
+                                dtype=np.float64)
+
+    future_states_array = convert_absolute_quantities_to_relative(
+        future_states_array, anchor_ego_state, 'ego')
+
+    future = np.zeros(
+        (future_states_array.shape[0], future_states_array.shape[1] + 1 + 3),
+        dtype=np.float32,
+    )
+    future[:, :2] = future_states_array[:, :2]
+    future[:, 2] = np.cos(future_states_array[:, 2])
+    future[:, 3] = np.sin(future_states_array[:, 2])
+    future[:, 4:8] = future_states_array[:, 3:]
+    future[:, 8] = 1.0  # ego vehicle is always a car
+
     # Get all future poses of the ego relative to the ego coordinate system
     future_trajectory_relative_poses = convert_absolute_to_relative_poses(
         current_ego_state.rear_axle,
         [state.rear_axle for state in future_trajectory_absolute_states])
 
-    return future_trajectory_relative_poses
+    return future_trajectory_relative_poses, future
 
 
 def calculate_additional_ego_states(ego_agent_past, time_stamp):

--- a/diffusion_planner/train_epoch.py
+++ b/diffusion_planner/train_epoch.py
@@ -42,6 +42,9 @@ def train_epoch(data_loader,
             route_lanes_has_speed_limit,
 
             static_objects,
+            neighbors_future_gt_all
+            ego_future_gt_11_dim, = ego_agent_future_11_dim
+
 
             '''
 
@@ -60,7 +63,8 @@ def train_epoch(data_loader,
                 'route_lanes_speed_limit': batch[9].to(args.device),
                 'route_lanes_has_speed_limit': batch[10].to(args.device),
 
-                'static_objects': batch[11].to(args.device)
+                'static_objects': batch[11].to(args.device),
+                'ego_future_gt_11_dim': batch[13].to(args.device),
 
             }
 
@@ -87,6 +91,7 @@ def train_epoch(data_loader,
 
             mask = torch.sum(torch.ne(neighbors_future[..., :3], 0),
                              dim=-1) == 0
+            # neighbors_future shape: [B, N, T, 4]
             neighbors_future = torch.cat(
                 [
                     neighbors_future[..., :2],

--- a/diffusion_planner/utils/dataset.py
+++ b/diffusion_planner/utils/dataset.py
@@ -23,6 +23,7 @@ class DiffusionPlannerData(Dataset):
         ego_agent_past = data['ego_agent_past']
         ego_current_state = data['ego_current_state']
         ego_agent_future = data['ego_agent_future']
+        ego_agent_future_11_dim = data['ego_agent_future_11_dim']
 
         neighbor_agents_past = data['neighbor_agents_past'][:self.
                                                             _past_neighbor_num]
@@ -54,6 +55,7 @@ class DiffusionPlannerData(Dataset):
             "route_lanes_has_speed_limit": route_lanes_has_speed_limit,
             "static_objects": static_objects,
             "neighbors_future_gt_all": neighbor_agents_future_all,
+            "ego_future_gt_11_dim": ego_agent_future_11_dim,
         }
 
         return tuple(data.values())


### PR DESCRIPTION
## Summary
- encode ego future trajectories with full kinematic and type features
- validate ego future array dimensions during preprocessing

## Testing
- `python -m py_compile diffusion_planner/data_process/ego_process.py diffusion_planner/data_process/data_processor.py`
- `pytest -q` *(fails: No module named 'numpy')*
- `pip install numpy -q` *(fails: Could not find a version that satisfies the requirement numpy)*
- `apt-get update -y` *(fails: repository access forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689c3c9724e4832d907e7dab5b0c85b3