### PR TITLE
Avoid in-place addition in DiTBlock

### DIFF
--- a/diffusion_planner/model/module/dit.py
+++ b/diffusion_planner/model/module/dit.py
@@ -137,7 +137,7 @@ class DiTBlock(nn.Module):
         cross_out = torch.nan_to_num(cross_out, nan=0.0, posinf=0.0,
                                      neginf=0.0)  # ← NaN → 0
         x = x + self.gate_cross * cross_out
-        x += self.gate_mlp2  * self.mlp2(self.norm4(x))
+        x = x + self.gate_mlp2 * self.mlp2(self.norm4(x))
 
         return x
 


### PR DESCRIPTION
## Summary
- replace in-place addition in `DiTBlock.forward` with out-of-place add to avoid autograd issues
- ensure no other in-place tensor additions remain in `dit.py`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'timm', ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy timm` *(fails: 403 Forbidden when downloading packages)*

------
https://chatgpt.com/codex/tasks/task_e_68aa945a62e4832dbd2918b3903bc29c