### PR TITLE
디코더 NaN 추적을 위한 진단 코드 추가

### DIFF
--- a/diffusion_planner/model/module/decoder.py
+++ b/diffusion_planner/model/module/decoder.py
@@ -9,6 +9,7 @@ from diffusion_planner.model.diffusion_utils.sde import SDE, VPSDE_linear
 from diffusion_planner.utils.normalizer import ObservationNormalizer, StateNormalizer
 from diffusion_planner.model.module.mixer import MixerBlock
 from diffusion_planner.model.module.dit import TimestepEmbedder, DiTBlock, FinalLayer
+from diffusion_planner.loss import _require_finite
 
 
 class Decoder(nn.Module):
@@ -103,17 +104,16 @@ class Decoder(nn.Module):
                 B, Pnn, -1)  # [B, Pnn, 1 + T, 4] -> [B, Pnn, (1 + T) * 4]
             diffusion_time = inputs['diffusion_time']
             # (B, Pnn, (1 + T) , 4)
-            return {
-                "score":
-                    self.dit(
-                        near_cur_future_norm_xT,  # ( B, Pnn, (1 + T) * 4 )
-                        diffusion_time,  # (B)
-                        scene_encoding_token,  # (B, token_num, hidden_dim)
-                        ego_fut_global,  # (B, hidden_dim)
-                        near_current_mask,  # (B, Pnn),
-                        scene_encoding_token_mask  # (B, token_num) bool
-                    ).reshape(B, Pnn, -1, 4)  #  (B, Pnn, (1 + T) , 4)
-            }
+            score = self.dit(
+                near_cur_future_norm_xT,  # ( B, Pnn, (1 + T) * 4 )
+                diffusion_time,  # (B)
+                scene_encoding_token,  # (B, token_num, hidden_dim)
+                ego_fut_global,  # (B, hidden_dim)
+                near_current_mask,  # (B, Pnn),
+                scene_encoding_token_mask  # (B, token_num) bool
+            )
+            _require_finite("decoder_dit_output", score)
+            return {"score": score.reshape(B, Pnn, -1, 4)}  #  (B, Pnn, (1 + T) , 4)
         else:
             # [B, Pnn, (1 + future_len) * 4]
             xT = torch.cat(

--- a/train_predictor.py
+++ b/train_predictor.py
@@ -349,6 +349,8 @@ def model_training(args):
 
     # set seed
     set_seed(args.seed + global_rank)
+    # Enable anomaly detection to trace NaN/Inf origins during training
+    torch.autograd.set_detect_anomaly(True)
 
     # training parameters
     train_epochs = args.train_epochs


### PR DESCRIPTION
## 요약
- 학습 진입점에 `torch.autograd.set_detect_anomaly(True)` 추가로 NaN/Inf 추적 강화
- 디코더 DiT 출력 직후 `_require_finite` 검증으로 수치 이상 조기 감지

## 테스트
- `python -m py_compile train_predictor.py diffusion_planner/model/module/decoder.py`
- `pytest` *(모듈 누락으로 실패: `timm`, `numpy`)*

------
https://chatgpt.com/codex/tasks/task_e_68aac6142dd8832da315d0733c0fb050