### PR TITLE
DiTBlock에서 완전 마스크 샘플 어텐션 생략 및 텐서 shape 주석 추가

### DIFF
--- a/diffusion_planner/model/module/dit.py
+++ b/diffusion_planner/model/module/dit.py
@@ -111,37 +111,50 @@ class DiTBlock(nn.Module):
             y: (B, D=192)
             attn_mask: near_current_mask: (B, Pnn)
             cross_mask: (B, token_num)
+
+        Note:
+            softmax 연산은 입력이 모두 마스킹된 경우 NaN을 발생시킬 수 있다.
+            이를 방지하기 위해 완전히 마스킹된 배치는 어텐션을 건너뛰고
+            출력 텐서를 0으로 초기화한다.
         """
         # y: (B, D=192)
         (shift_msa, scale_msa, gate_msa, shift_mlp, scale_mlp,
          gate_mlp) = self.adaLN_modulation(y).chunk(6, dim=1)
 
 
-        modulated_x = modulate(self.norm1(x), shift_msa, scale_msa)
-        msa_out = self.attn(
-            modulated_x, modulated_x, modulated_x,
-            key_padding_mask=attn_mask,
-            need_weights=False  # ← 가중치 미계산
-        )[0]
-        msa_out[attn_mask.all(dim=1)] = 0
+        modulated_x = modulate(self.norm1(x), shift_msa, scale_msa)  # (B, P, D)
+        # 모든 토큰이 마스킹된 배치는 NaN을 방지하기 위해 어텐션을 생략한다
+        msa_out = torch.zeros_like(x)  # (B, P, D)
+        valid_mask = ~attn_mask.all(dim=1)  # (B,)
+        if valid_mask.any():
+            msa_out[valid_mask] = self.attn(
+                modulated_x[valid_mask],  # (B_valid, P, D)
+                modulated_x[valid_mask],  # (B_valid, P, D)
+                modulated_x[valid_mask],  # (B_valid, P, D)
+                key_padding_mask=attn_mask[valid_mask],  # (B_valid, P)
+                need_weights=False,
+            )[0]  # (B_valid, P, D)
         msa_out = torch.nan_to_num(msa_out, nan=0.0, posinf=0.0,
-                                   neginf=0.0)  # ← NaN → 0 # (B, P, D)
+                                   neginf=0.0)  # (B, P, D)
         x = x + gate_msa.unsqueeze(1) * msa_out  # (B, P, D)
 
         modulated_x = modulate(self.norm2(x), shift_mlp, scale_mlp)
         x = x + gate_mlp.unsqueeze(1) * self.mlp1(modulated_x)
 
-        q = self.norm3(x)
-        if cross_mask.all(dim=1).any():
-            cross_out = torch.zeros_like(x)
-        else:
-            cross_out = self.cross_attn(
-                q, cross_c, cross_c,
-                key_padding_mask=cross_mask,
-                need_weights=False
-            )[0]
+        q = self.norm3(x)  # (B, P, D)
+        cross_out = torch.zeros_like(x)  # (B, P, D)
+        valid_cross = ~cross_mask.all(dim=1)  # (B,)
+        if valid_cross.any():
+            cross_out[valid_cross] = self.cross_attn(
+                q[valid_cross],  # (B_valid, P, D)
+                cross_c[valid_cross],  # (B_valid, N, D)
+                cross_c[valid_cross],  # (B_valid, N, D)
+                key_padding_mask=cross_mask[valid_cross],  # (B_valid, N)
+                need_weights=False,
+            )[0]  # (B_valid, P, D)
+        # 교차 어텐션에서도 완전히 마스크된 배치는 0으로 채워 NaN을 방지한다
         cross_out = torch.nan_to_num(cross_out, nan=0.0, posinf=0.0,
-                                     neginf=0.0)  # ← NaN → 0
+                                     neginf=0.0)  # (B, P, D)
         x = x + self.gate_cross * cross_out
         x = x + self.gate_mlp2 * self.mlp2(self.norm4(x))
 


### PR DESCRIPTION
## 요약
- 완전히 마스크된 배치에 대해 self-attention과 cross-attention을 생략하고 출력 텐서를 0으로 초기화
- 마스크 건너뛰기 로직에 텐서 shape 주석을 추가하여 가독성 향상

## 테스트
- `pytest` *(모듈 누락으로 실패: ModuleNotFoundError: No module named 'timm'; ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy timm` *(실패: Tunnel connection failed: 403 Forbidden; No matching distribution found for numpy)*

------
https://chatgpt.com/codex/tasks/task_e_68aacfc8251c832dbad2c154bbe191d3