### PR TITLE
feat: TensorBoard 메트릭을 W&B와 동기화

### DIFF
--- a/diffusion_planner/utils/tb_log.py
+++ b/diffusion_planner/utils/tb_log.py
@@ -62,7 +62,8 @@ class TensorBoardLogger():
                                   name=run_name,
                                   notes=notes,
                                   resume='allow',
-                                  id=wandb_resume_id)
+                                  id=wandb_resume_id,
+                                  sync_tensorboard=True)  # TensorBoard 로그를 W&B와 자동 동기화
             self.id = self.run.id
             wandb.config.update(args, allow_val_change=allow_val_change)
 
@@ -77,6 +78,8 @@ class TensorBoardLogger():
         if self.writer is not None:
             for key, value in metrics.items():
                 self.writer.add_scalar(key, value, step)
+            if wandb.run:  # W&B 대시보드에서도 동일한 메트릭을 보기 위해 추가
+                wandb.log(metrics, step=step)
 
     def finish(self):
         if self.writer is not None:


### PR DESCRIPTION
## Summary
- TensorBoard 로그를 W&B에 자동 동기화
- W&B 대시보드에서도 메트릭을 볼 수 있도록 wandb.log 추가
- 변경 코드의 목적을 설명하는 한글 주석 추가

## Testing
- `pytest -q` *(모듈 'timm', 'numpy' 없음)*
- `./torch_run_ceph.sh --use_wandb True` *(인터프리터 경로 없음: /mnt/nuplan/miniforge/envs/diffusion_planner/bin/python)*

------
https://chatgpt.com/codex/tasks/task_e_68aadc69af10832d811f41997515a31d