### PR TITLE
Add autocast context and document TF32 backend settings

### DIFF
--- a/diffusion_planner/model/module/dit.py
+++ b/diffusion_planner/model/module/dit.py
@@ -155,8 +155,9 @@ class DiTBlock(nn.Module):
     def _get_compute_dtype(x: torch.Tensor) -> torch.dtype:
         """연산 dtype을 선택합니다(BF16/FP16 우선).
 
-        Autocast/AMP와의 정합성을 위해 입력 텐서 `x`의 dtype이 FP16/BF16이면 그대로,
-        아니라면 기본적으로 FP16을 사용해 FlashAttention‑2가 빠르게 동작하도록 합니다.
+        1) autocast가 켜져 있으면 해당 dtype을 우선 사용합니다.
+        2) 입력 텐서 `x`가 FP16/BF16이면 그대로 사용합니다.
+        3) 그 외에는 GPU 아키텍처에 따라 BF16(>=SM80) 또는 FP16을 반환합니다.
 
         Args:
             x (torch.Tensor): 임의 텐서. (shape 무관)
@@ -164,8 +165,20 @@ class DiTBlock(nn.Module):
         Returns:
             torch.dtype: 연산에 사용할 dtype (torch.float16 또는 torch.bfloat16).
         """
-        return x.dtype if x.dtype in (torch.float16,
-                                      torch.bfloat16) else torch.float16
+        if torch.is_autocast_enabled():
+            try:
+                return torch.get_autocast_gpu_dtype()
+            except Exception:
+                pass
+
+        if x.dtype in (torch.float16, torch.bfloat16):
+            return x.dtype
+
+        if x.is_cuda and torch.cuda.is_available():
+            major, _ = torch.cuda.get_device_capability(x.device)
+            return torch.bfloat16 if major >= 8 else torch.float16
+
+        return torch.float16
 
     @staticmethod
     def _unpad_from_mask(

--- a/diffusion_planner/model/module/encoder.py
+++ b/diffusion_planner/model/module/encoder.py
@@ -455,8 +455,9 @@ class SelfAttentionBlock(nn.Module):
     def _get_compute_dtype(x: torch.Tensor) -> torch.dtype:
         """연산 dtype을 선택합니다(BF16/FP16 우선).
 
-        AMP/autocast와의 정합성을 위해 입력 텐서 `x`의 dtype이 FP16/BF16이면 그대로,
-        아니라면 FP16을 사용하여 FlashAttention‑2의 장점을 극대화합니다.
+        1) autocast가 켜져 있으면 해당 dtype을 우선 사용합니다.
+        2) 입력 텐서 `x`가 FP16/BF16이면 그대로 사용합니다.
+        3) 그 외에는 GPU 아키텍처에 따라 BF16(>=SM80) 또는 FP16을 반환합니다.
 
         Args:
             x (torch.Tensor): 임의 텐서. (shape 무관)
@@ -464,8 +465,20 @@ class SelfAttentionBlock(nn.Module):
         Returns:
             torch.dtype: torch.float16 또는 torch.bfloat16
         """
-        return x.dtype if x.dtype in (torch.float16,
-                                      torch.bfloat16) else torch.float16
+        if torch.is_autocast_enabled():
+            try:
+                return torch.get_autocast_gpu_dtype()
+            except Exception:
+                pass
+
+        if x.dtype in (torch.float16, torch.bfloat16):
+            return x.dtype
+
+        if x.is_cuda and torch.cuda.is_available():
+            major, _ = torch.cuda.get_device_capability(x.device)
+            return torch.bfloat16 if major >= 8 else torch.float16
+
+        return torch.float16
 
     @staticmethod
     def _unpad_from_mask(

--- a/diffusion_planner/planner/planner.py
+++ b/diffusion_planner/planner/planner.py
@@ -18,6 +18,7 @@ from nuplan.planning.simulation.planner.abstract_planner import (
 from diffusion_planner.model.diffusion_planner import Diffusion_Planner
 from diffusion_planner.data_process.data_processor import DataProcessor
 from diffusion_planner.utils.config import Config
+from diffusion_planner.utils.amp import amp_context_for_infer
 
 
 def identity(ego_state, predictions):
@@ -133,7 +134,12 @@ class DiffusionPlanner(AbstractPlanner):
         inputs = self.planner_input_to_model_inputs(current_input)
 
         inputs = self.observation_normalizer(inputs)
-        _, outputs = self._planner(inputs)
+        with torch.inference_mode():
+            if self._device == "cuda":
+                with amp_context_for_infer():
+                    _, outputs = self._planner(inputs)
+            else:
+                _, outputs = self._planner(inputs)
 
         trajectory = InterpolatedTrajectory(
             trajectory=self.outputs_to_trajectory(

--- a/diffusion_planner/train_epoch.py
+++ b/diffusion_planner/train_epoch.py
@@ -9,6 +9,8 @@ from diffusion_planner.loss import diffusion_loss_func
 from diffusion_planner.utils.data_augmentation import StatePerturbation
 from diffusion_planner.utils.npc_data_augmentation import NPCStatePerturbation
 
+AMP_DTYPE = torch.bfloat16  # A100 권장 dtype
+
 
 def train_epoch(data_loader,
                 model,
@@ -105,21 +107,21 @@ def train_epoch(data_loader,
                     "Non-finite values detected in neighbors_future")
             norm_inputs = args.observation_normalizer(inputs)
 
-            # call the mdoel
-            optimizer.zero_grad()
+            # call the model
+            optimizer.zero_grad(set_to_none=True)
             loss = {}
             """
             ego_future.shape: [8, 80, 4]
             neighbors_future.shape: [8, 10, 80, 4]
             mask.shape: [8, 10, 80]
             """
-            loss, _ = diffusion_loss_func(
-                model, norm_inputs,
-                ddp.get_model(model, args.ddp).sde.marginal_prob,
-                (neighbors_future, mask), args.state_normalizer,
-                loss, args.diffusion_model_type)
-
-            loss['loss'] = loss['neighbor_prediction_loss']
+            with torch.autocast("cuda", dtype=AMP_DTYPE):
+                loss, _ = diffusion_loss_func(
+                    model, norm_inputs,
+                    ddp.get_model(model, args.ddp).sde.marginal_prob,
+                    (neighbors_future, mask), args.state_normalizer,
+                    loss, args.diffusion_model_type)
+                loss['loss'] = loss['neighbor_prediction_loss']
 
             total_loss = loss['loss'].item()  # scalar
 

--- a/diffusion_planner/utils/amp.py
+++ b/diffusion_planner/utils/amp.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+import contextlib
+import torch
+from typing import Dict, Any, Iterator
+
+
+def amp_context_for_infer() -> Iterator[None]:
+    """장비에 맞춰 추론용 autocast를 자동 선택합니다.
+
+    - A100/RTX30/40 등 BF16 지원 GPU: BF16
+    - 그 외 CUDA GPU: FP16
+    - CPU: autocast 없음(FP32)
+    """
+    if torch.cuda.is_available():
+        # 암페어 이상이면 True (A100/RTX30/40 등)
+        if torch.cuda.is_bf16_supported():
+            return torch.autocast("cuda", dtype=torch.bfloat16)
+        else:
+            return torch.autocast("cuda", dtype=torch.float16)
+    return contextlib.nullcontext()

--- a/nuplan_extent/planning/training/modeling/models/world_model.py
+++ b/nuplan_extent/planning/training/modeling/models/world_model.py
@@ -13,6 +13,7 @@ from nuplan.planning.training.preprocessing.target_builders.abstract_target_buil
 from nuplan_extent.planning.training.preprocessing.features.world_model import WorldModelFeature
 from diffusion_planner.utils.config import Config
 from diffusion_planner.model.diffusion_planner import Diffusion_Planner
+from diffusion_planner.utils.amp import amp_context_for_infer
 from nuplan.planning.simulation.trajectory.interpolated_trajectory import InterpolatedTrajectory
 from nuplan.planning.simulation.planner.ml_planner.transform_utils import transform_predictions_to_states
 
@@ -82,7 +83,9 @@ class WorldModel(TorchModuleWrapper):
         :param features: A dictionary of the required features.
         """
         inputs: Dict[str, Optional[torch.Tensor]] = features.to_tensor_dict()
-        _, outputs = self._planner(inputs)
+        with torch.inference_mode():
+            with amp_context_for_infer():
+                _, outputs = self._planner(inputs)
         """
         outputs: Dict[str, torch.Tensor]
             "prediction" : (B, Pnn, T, 4)

--- a/train_predictor.py
+++ b/train_predictor.py
@@ -4,6 +4,11 @@ os.environ["PYTORCH_CUDA_ALLOC_CONF"] = "max_split_size_mb:128"
 # DDP 디버깅을 위해 사용되지 않은 파라미터 정보를 상세히 출력
 os.environ.setdefault("TORCH_DISTRIBUTED_DEBUG", "DETAIL")
 import torch
+# TensorFloat-32(TF32) 연산을 허용하여
+#   - Ampere(A100 등) GPU에서 matmul/cuDNN 연산을 FP32보다 빠르게 처리하고
+#   - 눈에 띄는 정밀도 손실 없이 학습·추론 속도를 높이기 위한 설정입니다.
+torch.backends.cuda.matmul.allow_tf32 = True
+torch.backends.cudnn.allow_tf32 = True
 import argparse
 import shutil
 from torch import optim


### PR DESCRIPTION
## Summary
- Add amp_context_for_infer utility for BF16/FP16 inference autocast
- Enable BF16 autocast in Diffusion Planner and training loops
- Explain TensorFloat-32 backend flags in `train_predictor.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'timm'; ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy timm` *(fails: Could not find a version that satisfies the requirement numpy)*

------
https://chatgpt.com/codex/tasks/task_e_68baa1e2f450832da031b5b927d4f895